### PR TITLE
Added query_child method

### DIFF
--- a/lib/business_central/api_methods.rb
+++ b/lib/business_central/api_methods.rb
@@ -92,6 +92,12 @@ module BusinessCentral
       process(response)
     end
 
+    def query_child(parent_id, query)
+      response = @client.get("/#{api_object_parent}(#{parent_id})/#{api_object}?$filter=#{query}")
+      handle_error(response)
+      process(response)
+    end
+
     # Performs the POST operation on the supplied args
     #
     # @param args [Array]]

--- a/lib/business_central/version.rb
+++ b/lib/business_central/version.rb
@@ -1,3 +1,3 @@
 module BusinessCentral
-  VERSION = "0.9.3"
+  VERSION = "0.9.4"
 end

--- a/test/business_central/sales_invoice_line_test.rb
+++ b/test/business_central/sales_invoice_line_test.rb
@@ -26,6 +26,17 @@ class BusinessCentral::SalesInvoiceLineTest < Test::Unit::TestCase
     assert_equal "LONDON Swivel Chair, blue", invoiceLines.first.description
   end
 
+  test "should return filtered invoice lines for a given salesInvoice" do
+    stub_get("salesInvoices(1234)/salesInvoiceLines?$filter=lineType%20eq%20'Item'").
+      with(headers: stub_headers).
+      to_return(status: 200, body: fixture("get_salesInvoiceLines_200.json"))
+
+    invoiceLines = BusinessCentral::SalesInvoiceLine.new(bc_client).
+      query_child("1234", "lineType eq 'Item'")
+
+    assert invoiceLines.is_a?(Array)
+  end
+
   test "should return salesInvoiceLines when only one line exists" do
     stub_get("salesInvoices(1234)/salesInvoiceLines").
       with(headers: stub_headers).


### PR DESCRIPTION
Allows filter querying of child objects. For example, salesInvoiceLines

GET /salesInvoices(1234)/salesInvoiceLines?$filter=lineType eq 'Item'

would return only Item type salesInvoiceLines